### PR TITLE
feat: Spanish voice support with language detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +22,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anyhow"
@@ -382,6 +400,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -801,6 +829,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "whatlang",
 ]
 
 [[package]]
@@ -1892,6 +1921,16 @@ checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "whatlang"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "471d1c1645d361eb782a1650b1786a8fb58dd625e681a04c09f5ff7c8764a7b0"
+dependencies = [
+ "hashbrown 0.14.5",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 thiserror = "2"
 dotenvy = "0.15"
 tokio-util = "0.7"
+whatlang = "0.16"

--- a/config.example.toml
+++ b/config.example.toml
@@ -19,6 +19,8 @@ model = "whisper-large-v3-turbo"
 # Secret loaded from .env (ELEVENLABS_API_KEY)
 api_key = ""
 voice_id = "JAgnJveGGUh4qy4kh6dF"
+# Optional: voice ID for Spanish responses (auto-detected via language detection)
+# spanish_voice_id = "avokGQLR6UbUx9DZNelE"
 
 [claude]
 # Uses `claude` CLI from PATH — no API key needed

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,8 @@ pub struct ElevenLabsConfig {
     pub api_key: String,
     #[serde(default = "default_voice_id")]
     pub voice_id: String,
+    #[serde(default)]
+    pub spanish_voice_id: Option<String>,
 }
 
 fn default_voice_id() -> String {

--- a/src/pipeline/tts.rs
+++ b/src/pipeline/tts.rs
@@ -14,14 +14,20 @@ impl TtsClient {
         }
     }
 
-    /// Convert text to audio bytes (PCM 16-bit, 8kHz mono).
-    ///
-    /// ElevenLabs returns mp3 by default, but we request PCM format
-    /// directly at 8kHz for easy mu-law encoding.
+    /// Convert text to audio bytes (PCM 16-bit, 8kHz mono) using the default voice.
     pub async fn synthesize(&self, text: &str) -> Result<Vec<u8>, TtsError> {
+        self.synthesize_with_voice(text, &self.voice_id).await
+    }
+
+    /// Convert text to audio bytes (PCM 16-bit, 8kHz mono) using an explicit voice ID.
+    pub async fn synthesize_with_voice(
+        &self,
+        text: &str,
+        voice_id: &str,
+    ) -> Result<Vec<u8>, TtsError> {
         let url = format!(
             "https://api.elevenlabs.io/v1/text-to-speech/{}",
-            self.voice_id
+            voice_id
         );
 
         let body = serde_json::json!({


### PR DESCRIPTION
## Summary
- Add `whatlang` dependency for lightweight language detection
- Auto-detect Spanish in Claude's responses and switch to a configurable Spanish ElevenLabs voice (`spanish_voice_id`)
- Refactor `TtsClient` with `synthesize_with_voice()` to support per-request voice selection
- Greeting always uses the default (English) voice

Closes #17

## Test plan
- [ ] Deploy to VPS with `spanish_voice_id` configured
- [ ] Call and speak in Spanish — confirm Spanish voice is used
- [ ] Call and speak in English — confirm default voice is used
- [ ] Call without `spanish_voice_id` set — confirm default behavior unchanged