### PR TITLE
docs: update README diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ Built in Rust. Uses Twilio for telephony, Groq Whisper for speech-to-text, Eleve
                                  └──────────────────┘
 ```
 
+### Full System
+
+```
+                     ┌──────────┐
+  ┌─────────┐        │   n8n    │        ┌───────────────┐
+  │ Triggers │──────►│ (Docker) │──────►│ trinity-echo  │──► Claude CLI
+  │ (cron,   │       │          │  API   │ (Rust, axum)  │
+  │  webhook,│       │  orchest.│        └───────┬───────┘
+  │  alerts, │       │  call-   │                │
+  │  events) │       │  human   │                ▼
+  └─────────┘        └──────────┘        ┌───────────────┐
+                                         │    Twilio      │◄──► Phone
+                                         └───────────────┘
+```
+
 ## How It Works
 
 ### Inbound calls


### PR DESCRIPTION
## Summary

- Remove external service references from README, keep focus on trinity-echo
- Add full system diagram back showing n8n → trinity-echo → Twilio flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)