### PR TITLE
feat(#34): inject SOUL.md via --append-system-prompt

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -28,6 +28,8 @@ session_timeout_secs = 300
 greeting = "Hello, this is Trinity"
 # Allow claude CLI to run tools without permission prompts (use with caution)
 dangerously_skip_permissions = false
+# Path to soul document injected as system prompt on every turn
+# soul_path = "/path/to/SOUL.md"
 
 [api]
 # Secret loaded from .env (TRINITY_API_TOKEN)

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,6 +61,8 @@ pub struct ClaudeConfig {
     pub greeting: String,
     #[serde(default)]
     pub dangerously_skip_permissions: bool,
+    #[serde(default)]
+    pub soul_path: Option<String>,
 }
 
 fn default_session_timeout() -> u64 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,6 +128,11 @@ async fn server() {
         claude: Arc::new(ClaudeBridge::new(
             config.claude.session_timeout_secs,
             config.claude.dangerously_skip_permissions,
+            config
+                .claude
+                .soul_path
+                .as_ref()
+                .map(std::path::PathBuf::from),
         )),
         twilio: Arc::new(TwilioClient::new(
             &config.twilio,


### PR DESCRIPTION
## Summary

- Adds `soul_path` config option to `[claude]` section — points to a soul document that defines the assistant's identity, values, and moral foundation
- ClaudeBridge reads the file fresh on every CLI invocation and injects it via `--append-system-prompt`
- Opt-in: commented out by default in `config.example.toml`, no behavior change unless configured

Closes #34

## Test plan

- [x] `cargo fmt && cargo clippy` — clean
- [x] `cargo build --release` — compiles
- [x] Deploy, set `soul_path` in config, restart service
- [ ] Call Trinity and ask about her values — response should reflect SOUL.md content
- [ ] Verify no regression on voice-first rules (no markdown, concise, natural speech)

🤖 Generated with [Claude Code](https://claude.com/claude-code)