### PR TITLE
Release v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "trinity-echo"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trinity-echo"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.80"
 description = "Voice interface for Claude Code via Twilio"


### PR DESCRIPTION
## Summary
- **VAD noise resilience**: bandpass filter, adaptive threshold, max utterance duration
- **SOUL.md injection**: Claude CLI now receives persona via `--append-system-prompt`
- **Security**: phone channel tagged as untrusted in Claude prompts
- **License**: switched from GPL-3.0 to MIT
- **Docs**: complete README with config fields, CLAUDE.md guidance, troubleshooting

## Version
0.4.2 → 0.5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)