### PR TITLE
Release v0.5.1 — Rename SOUL.md to SELF.md

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trinity-echo"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.80"
 description = "Voice interface for Claude Code via Twilio"

--- a/config.example.toml
+++ b/config.example.toml
@@ -28,8 +28,8 @@ session_timeout_secs = 300
 greeting = "Hello, this is Trinity"
 # Allow claude CLI to run tools without permission prompts (use with caution)
 dangerously_skip_permissions = false
-# Path to soul document injected as system prompt on every turn
-# soul_path = "/path/to/SOUL.md"
+# Path to self document injected as system prompt on every turn
+# self_path = "/path/to/SELF.md"
 
 [api]
 # Secret loaded from .env (TRINITY_API_TOKEN)

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,7 +62,7 @@ pub struct ClaudeConfig {
     #[serde(default)]
     pub dangerously_skip_permissions: bool,
     #[serde(default)]
-    pub soul_path: Option<String>,
+    pub self_path: Option<String>,
 }
 
 fn default_session_timeout() -> u64 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,7 @@ async fn server() {
             config.claude.dangerously_skip_permissions,
             config
                 .claude
-                .soul_path
+                .self_path
                 .as_ref()
                 .map(std::path::PathBuf::from),
         )),

--- a/src/pipeline/claude.rs
+++ b/src/pipeline/claude.rs
@@ -9,7 +9,7 @@ pub struct ClaudeBridge {
     sessions: Arc<Mutex<HashMap<String, Session>>>,
     session_timeout: Duration,
     dangerously_skip_permissions: bool,
-    soul_path: Option<std::path::PathBuf>,
+    self_path: Option<std::path::PathBuf>,
 }
 
 struct Session {
@@ -21,13 +21,13 @@ impl ClaudeBridge {
     pub fn new(
         session_timeout_secs: u64,
         dangerously_skip_permissions: bool,
-        soul_path: Option<std::path::PathBuf>,
+        self_path: Option<std::path::PathBuf>,
     ) -> Self {
         Self {
             sessions: Arc::new(Mutex::new(HashMap::new())),
             session_timeout: Duration::from_secs(session_timeout_secs),
             dangerously_skip_permissions,
-            soul_path,
+            self_path,
         }
     }
 
@@ -55,8 +55,8 @@ impl ClaudeBridge {
             cmd.arg("--dangerously-skip-permissions");
         }
 
-        // Inject soul document if configured
-        if let Some(ref path) = self.soul_path {
+        // Inject self document if configured
+        if let Some(ref path) = self.self_path {
             if let Ok(contents) = std::fs::read_to_string(path) {
                 cmd.arg("--append-system-prompt").arg(contents);
             }


### PR DESCRIPTION
## Summary
- Rename `soul_path` config field to `self_path` across Rust source and example config
- Reflects identity document rename from SOUL.md to SELF.md

## Changes
- `Cargo.toml` — version bump to 0.5.1
- `src/config.rs` — `soul_path` → `self_path` in `ClaudeConfig` struct
- `src/pipeline/claude.rs` — field and comment references updated
- `src/main.rs` — config access updated
- `config.example.toml` — key and comment updated

## Test plan
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean
- [x] `cargo build --release` successful
- [x] Binary deployed and service restarted
- [x] claude-bridge server.py updated separately (not in repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)